### PR TITLE
Enable the chat endpoint to accept a model from the configuration file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ gym/cfg_test.yaml
 dataset/analyse_scenes.ipynb
 dataset/agent_data/**
 agent_data.zip
+**/.cache/

--- a/agent/agentmodule.py
+++ b/agent/agentmodule.py
@@ -807,6 +807,7 @@ class Executor(Trigger):
                     case 'chat':
                         func_params.update({
                             'api_key' : self.api_key,
+                            'model' : self.model,
                             'base_url': self.base_url,
                             'messages': json.dumps(infos["events"])})
 

--- a/agent/main.py
+++ b/agent/main.py
@@ -68,7 +68,7 @@ async def search(query: str, search_engine:str = 'bing') -> Dict[str,str]:
     return await toolreg["search"](query, search_engine)
 
 @app.get('/chat')
-async def chat(messages: str, api_key:str = "", base_url:Optional[str] = None) -> Dict[str,str]:
+async def chat(messages: str, api_key:str = "", model:Optional[str] = "gpt-3.5-turbo", base_url:Optional[str] = None) -> Dict[str,str]:
     """
     chat with ChatGPT-3.5-turbo. This function will call the chat tool, and pass the message to the chatbot, the response will be copied in the clipboard. Details in register/tools/chat.py
     You can modity the default model by modifying the `model` variable in `register/tools/chat.py`.
@@ -84,7 +84,7 @@ async def chat(messages: str, api_key:str = "", base_url:Optional[str] = None) -
         else, return {'status': 'error', 'error': error message}
     """
     # print(messages)
-    return await toolreg["chat"](messages,api_key = api_key, base_url = base_url)
+    return await toolreg["chat"](messages, api_key = api_key, model = model, base_url = base_url)
 
 @app.get('/read')
 async def read(filepath: str, line_number: int = 1) -> Dict[str,str]:

--- a/agent/register/tools/chat.py
+++ b/agent/register/tools/chat.py
@@ -12,6 +12,7 @@ If the assistant ask you to generate code, you should only generate code without
 @toolwrapper(name="chat",visible=True)
 async def chat(messages: str = "Who are you?",
                 api_key :str = "",
+                model:Optional[str] = "gpt-3.5-turbo",
                 base_url:Optional[str] = None):
     """
     This function is used to chat with the OpenAI API, or to chat with the gpt. The funtion will copy the response to the clipboard, and return a status indicating if the function is successful or not.
@@ -28,7 +29,7 @@ async def chat(messages: str = "Who are you?",
     print('====>', messages)
     client = OpenAI(api_key = api_key, base_url = base_url)
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model=model,
         messages = [{"role": "user", "content": BASIC_PROMPT.format(infos=messages)}]
     )
     # print(response.choices[0].message.content)


### PR DESCRIPTION
I noticed that in the agentmodule, the model configuration information for the chat endpoint is initialized based on private.toml, but the model is not passed as a parameter to the server's chat endpoint for configuration. Therefore, I modified the code to allow it to accept a model name for model configuration.